### PR TITLE
feature: no renderIf error

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,10 +50,23 @@ const noCustomMoment = {
   }
 }
 
+const noRenderIf = {
+  create: function (context) {
+    return {
+      CallExpression (node) {
+        if (node.callee.name !== 'renderIf') return
+
+        context.report(node, 'renderIf is deprecated. Use conditional rendering: https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator')
+      }
+    }
+  }
+}
+
 module.exports = {
   rules: {
     'no-import-react': noImportReact,
     'no-autobind': noAutobind,
-    'no-custom-moment': noCustomMoment
+    'no-custom-moment': noCustomMoment,
+    'no-render-if': noRenderIf
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-plugin-factorial",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "index.js"
 }


### PR DESCRIPTION
More and more we see developers resorting to conditional rendering
instead of using our renderIf library. Let's not fight the tide and join
forces: adding a rule to announce deprecation of renderIf library.